### PR TITLE
use batching to remove duplicated messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,11 @@ So in the response you will able to see only `1000` messages
 
 _Note:_
 
-If you notice duplicated messages, it could indicate that the user edited a message that was originally written earlier.
+All Slack messages are collected to the batches and sent to the storage via the interval of time. 
+So this logic should prevent duplicated messages when the user edits the message. 
+But if the message is edited after the time limit, it can appear as duplicate.
+Time interval for new messages to be appeared in the storage is `15 minute`.
+
 
 ### How to find messages by specific keywords of part of the message
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module slack2logs
 
-go 1.21.1
+go 1.22
 
 require (
 	github.com/VictoriaMetrics/metrics v1.24.0
 	github.com/slack-go/slack v0.12.3
 	github.com/valyala/fasttemplate v1.2.2
+	golang.org/x/exp v0.0.0-20240529005216-23cca8864a10
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/VictoriaMetrics/metrics v1.24.0
 	github.com/slack-go/slack v0.12.3
 	github.com/valyala/fasttemplate v1.2.2
-	golang.org/x/exp v0.0.0-20240529005216-23cca8864a10
 )
 
 require (
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fastrand v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/histogram v1.2.0 h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OLoQ=
 github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
-golang.org/x/exp v0.0.0-20240529005216-23cca8864a10 h1:vpzMC/iZhYFAjJzHU0Cfuq+w1vLLsF2vLkDrPjzKYck=
-golang.org/x/exp v0.0.0-20240529005216-23cca8864a10/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,9 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -23,6 +24,8 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/histogram v1.2.0 h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OLoQ=
 github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
+golang.org/x/exp v0.0.0-20240529005216-23cca8864a10 h1:vpzMC/iZhYFAjJzHU0Cfuq+w1vLLsF2vLkDrPjzKYck=
+golang.org/x/exp v0.0.0-20240529005216-23cca8864a10/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -47,18 +47,7 @@ func New(exporter Exporter, importer Importer) *Processor {
 // Run starts export import process
 func (p *Processor) Run(ctx context.Context) {
 	p.exporter.Export(func(m slack.Message) {
-		logMsg := LogMessage{
-			Type:                  m.Type,
-			User:                  m.User,
-			Text:                  m.Text,
-			ThreadTimeStamp:       m.ThreadTimeStamp,
-			TimeStamp:             m.TimeStamp,
-			ChannelID:             m.ChannelID,
-			ChannelName:           m.ChannelName,
-			UserID:                m.UserID,
-			DisplayName:           m.DisplayName,
-			DisplayNameNormalized: m.DisplayNameNormalized,
-		}
+		logMsg := LogMessage(m)
 		if err := p.importer.Import(ctx, logMsg); err != nil {
 			log.Printf("error import message to the importer: %s", err)
 		}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -47,7 +47,18 @@ func New(exporter Exporter, importer Importer) *Processor {
 // Run starts export import process
 func (p *Processor) Run(ctx context.Context) {
 	p.exporter.Export(func(m slack.Message) {
-		logMsg := LogMessage(m)
+		logMsg := LogMessage{
+			Type:                  m.Type,
+			User:                  m.User,
+			Text:                  m.Text,
+			ThreadTimeStamp:       m.ThreadTimeStamp,
+			TimeStamp:             m.TimeStamp,
+			ChannelID:             m.ChannelID,
+			ChannelName:           m.ChannelName,
+			UserID:                m.UserID,
+			DisplayName:           m.DisplayName,
+			DisplayNameNormalized: m.DisplayNameNormalized,
+		}
 		if err := p.importer.Import(ctx, logMsg); err != nil {
 			log.Printf("error import message to the importer: %s", err)
 		}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -16,7 +16,7 @@ type Importer interface {
 // Exporter defines exporter interface
 // which should be implemented for each exporter
 type Exporter interface {
-	Export(func(slack.Message))
+	Export(context.Context, func(slack.Message))
 }
 
 // Processor defines object with exporter and importer
@@ -46,7 +46,7 @@ func New(exporter Exporter, importer Importer) *Processor {
 
 // Run starts export import process
 func (p *Processor) Run(ctx context.Context) {
-	p.exporter.Export(func(m slack.Message) {
+	p.exporter.Export(ctx, func(m slack.Message) {
 		logMsg := LogMessage(m)
 		if err := p.importer.Import(ctx, logMsg); err != nil {
 			log.Printf("error import message to the importer: %s", err)

--- a/slack/client.go
+++ b/slack/client.go
@@ -21,13 +21,13 @@ import (
 
 const (
 	historicalRequestLimit = 500
-	batchSendInterval      = 30 * time.Second // 15 minutes
 )
 
 var (
-	botToken          = flag.String("slack.auth.botToken", "", "Bot user OAuth token for Your Workspace")
-	appToken          = flag.String("slack.auth.appToken", "", "App-level tokens allow your app to use platform features that apply to multiple (or all) installations")
-	listeningChannels = flagutil.NewArrayString("slack.channels", "Channels ids from slack to listen messages")
+	botToken           = flag.String("slack.auth.botToken", "", "Bot user OAuth token for Your Workspace")
+	appToken           = flag.String("slack.auth.appToken", "", "App-level tokens allow your app to use platform features that apply to multiple (or all) installations")
+	listeningChannels  = flagutil.NewArrayString("slack.channels", "Channels ids from slack to listen messages")
+	batchFlushInterval = flag.Duration("slack.batchFlushInterval", 900*time.Second, "Interval for flushing batch of messages to the additional service")
 )
 
 var (
@@ -117,7 +117,8 @@ func (c *Client) RunHistoricalBackfilling(ctx context.Context) error {
 
 // Export sends slack message to the additional service via callback
 func (c *Client) Export(ctx context.Context, cb func(m Message)) {
-	ticker := time.NewTicker(batchSendInterval)
+	ticker := time.NewTicker(*batchFlushInterval)
+	log.Printf("flush interval: %s", *batchFlushInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/slack/client.go
+++ b/slack/client.go
@@ -308,6 +308,10 @@ func (c *Client) collectHistoricalMessages(ctx context.Context) {
 						ChannelID: channelID,
 						Timestamp: m.Timestamp,
 					}
+
+					if m.ThreadTimestamp == "" {
+						m.ThreadTimestamp = m.Timestamp
+					}
 					c.messageC <- Message{
 						Type:                  m.Type,
 						User:                  m.User,

--- a/slack/client.go
+++ b/slack/client.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	historicalRequestLimit = 500
-	batchSendInterval      = 10 * time.Second // 15 minutes
+	batchSendInterval      = 900 * time.Second // 15 minutes
 )
 
 var (

--- a/slack/client.go
+++ b/slack/client.go
@@ -118,7 +118,6 @@ func (c *Client) RunHistoricalBackfilling(ctx context.Context) error {
 // Export sends slack message to the additional service via callback
 func (c *Client) Export(ctx context.Context, cb func(m Message)) {
 	ticker := time.NewTicker(*batchFlushInterval)
-	log.Printf("flush interval: %s", *batchFlushInterval)
 	defer ticker.Stop()
 	for {
 		select {


### PR DESCRIPTION
Enable batching to remove dulicated messages when user edit it message. 
Messages will be sent to the storage after 15 minutes. 